### PR TITLE
大佬，发现您的项目引入了junit:junit@4.12组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.learn</groupId>
@@ -23,14 +21,14 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
     </dependency>
 
     <dependency>
@@ -41,35 +39,35 @@
       <dependency>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
-          <version>4.12</version>
+          <version>4.13.1</version>
       </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>RELEASE</version>
+      <version>4.13.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>RELEASE</version>
+      <version>4.13.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13</version>
+      <version>4.13.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Junit 信息泄露漏洞
缺陷组件：junit:junit@4.12
漏洞编号：CVE-2020-15250
漏洞描述：Junit是个人开发者的一个开放源代码的Java测试框架。
JUnit4 4.13.1之前版本存在信息泄露漏洞，该漏洞源于测试规则TemporaryFolder包含一个本地信息泄露漏洞。在类似Unix的系统中，系统的临时目录在该系统上的所有用户之间共享。因此，在将文件和目录写入此目录时，默认情况下，相同系统上的其他用户都可以读取它们。此漏洞不允许其他用户覆盖这些目录或文件的内容。这纯粹是一个信息披露的漏洞。如果JUnit测试编写了敏感信息，这个漏洞就会对您造成影响。
影响范围：[4.7, 4.13.1)
最小修复版本：4.13.1
缺陷组件引入路径：com.learn:Thread@1.0-SNAPSHOT->junit:junit@4.12
```
另外我运行这个项目时，IDE的安全插件提示还有3个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p54de6